### PR TITLE
Avoid quoting for spaces in topics

### DIFF
--- a/resources/users.csv
+++ b/resources/users.csv
@@ -14,10 +14,10 @@ account,name,link,keywords,language
 @gau@scholar.social,Maxime Ulysse Garcia,https://scholar.social/@gau,cancer bioinformatics pipeline nfcore nextflow,en/fr
 @toniher@mastodont.cat,Toni Hermoso Pulido,https://mastodont.cat/@toniher,bioinformatics openscience devops,ca/en/es
 @DrK@qoto.org,Katy Knight,https://qoto.org/@DrK,STEM Bioinformatics genetics Linux RStats Radiography medicalimaging Devon politics,en
-@pragma@data-folks.masto.host,Manuel Belmadani,https://data-folks.masto.host/@pragma,datascience genomics transcriptomics proteomics computerscience pipelines,en/fr
-@isinaltinkaya@genomic.social,Isin Altinkaya,https://genomic.social/@isinaltinkaya,PopulationGenetics  StatisticalGenomics,en
+@pragma@data-folks.masto.host,Manuel Belmadani,https://data-folks.masto.host/@pragma,datascience genomics transcriptomics proteomics computer_science pipelines,en/fr
+@isinaltinkaya@genomic.social,Isin Altinkaya,https://genomic.social/@isinaltinkaya,Population_Genetics  Statistical_Genomics,en
 @jacquesdainat@genomic.social, Jacques Dainat, https://genomic.social/@jacquesdainat, bioinformatics epitranscripomics pipelines genome_annotation, en/fr
 @foaylward@genomic.social,Frank Aylward,https://genomic.social/@foaylward,ecology Microbial_Diversity,en
-@m_correa_m@fediscience.org,Miguel Correa,https://fediscience.org/@m_correa_m,protein "computational structural biology" "Machine Learning",en
+@m_correa_m@fediscience.org,Miguel Correa,https://fediscience.org/@m_correa_m,protein computational_structural_biology Machine_Learning,en
 @lwpembleton@genomic.social,Luke Pembleton,https://genomic.social/@lwpembleton,bioinformatics genomic_selection R nextflow genomics,en
 @jaymoore@genomic.social,Jay Moore,https://genomic.social/@jaymoore,bioinformatics gene_editing snakemake,en


### PR DESCRIPTION
This should solve a GitHub warning preventing the CSV rendering nicely there.

Instead uses underscore as per typical prior usage. Also added underscores to a couple of camel case topics.